### PR TITLE
Aspen Buildings+MultiZ code

### DIFF
--- a/_maps/map_files/SunnyDale/SunnyDale.dmm
+++ b/_maps/map_files/SunnyDale/SunnyDale.dmm
@@ -1,2608 +1,739 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
-"a" = (
-/turf/closed/indestructible/f13/matrix,
-/area/f13)
-"b" = (
-/turf/open/floor/plating/ground/desert,
-/area/f13)
+"aa" = (/turf/closed/indestructible/f13/matrix,/area/f13/farmhouse)
+"ab" = (/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"ac" = (/turf/open/space/basic,/area/space)
+"ad" = (/turf/closed/wall/f13/wood/painted,/area/f13/farmhouse)
+"ae" = (/turf/closed/wall/f13/wood/painted{icon_state = "wood2"},/area/f13/farmhouse)
+"af" = (/turf/open/floor/plating/ground/snow,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 4},/area/f13/farmhouse)
+"ag" = (/turf/open/floor/plating/ground/snow,/turf/closed/wall/f13/wood/painted{icon_state = "girder-middle"; dir = 8},/area/f13/farmhouse)
+"ah" = (/turf/open/floor/plating/ground/snow,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 8},/area/f13/farmhouse)
+"ai" = (/obj/item/flashlight/lamp,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aj" = (/obj/structure/barricade/wooden/snowed,/obj/structure/barricade/wooden/crude,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"ak" = (/turf/open/floor/plating/ice/smooth,/area/f13/farmhouse)
+"al" = (/obj/effect/decal/cleanable/dirt,/obj/structure/table/wood,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"am" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/obj/structure/table/wood,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"an" = (/turf/closed/wall/f13/wood/painted{icon_state = "wasteland12alt"},/area/f13/farmhouse)
+"ao" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ap" = (/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"aq" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_surround"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"ar" = (/obj/structure/table,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"as" = (/obj/structure/closet/secure_closet/freezer/fridge,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"at" = (/obj/structure/table,/obj/structure/showcase/machinery/microwave{name = "Microwave"},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"au" = (/turf/closed/wall/f13/wood/painted{icon_state = "wood1"},/area/f13/farmhouse)
+"av" = (/turf/open/floor/plating/ice/colder,/area/f13/farmhouse)
+"aw" = (/turf/open/floor/wood/f13/old{icon_state = "torncarpet9"},/area/f13/farmhouse)
+"ax" = (/obj/item/chair/wood/wings,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"ay" = (/obj/structure/fireplace,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"az" = (/turf/open/floor/wood/f13/old{icon_state = "torncarpet3"},/area/f13/farmhouse)
+"aA" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "torncarpet3"},/area/f13/farmhouse)
+"aB" = (/obj/structure/chair/wood/wings{icon_state = "wooden_chair_wings"; dir = 1},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"aC" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aD" = (/obj/item/bedsheet,/obj/structure/bed,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aE" = (/obj/structure/table/wood,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/old{icon_state = "torncarpet12"},/area/f13/farmhouse)
+"aF" = (/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aG" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"aH" = (/turf/closed/wall/f13/wood/painted{icon_state = "wasteland3alt"},/area/f13/farmhouse)
+"aI" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/old{icon_state = "torncarpet11"},/area/f13/farmhouse)
+"aJ" = (/turf/open/floor/wood/f13/stage_t,/area/f13/farmhouse)
+"aK" = (/obj/structure/closet/cardboard,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aL" = (/obj/item/chair/wood/wings{icon_state = "wooden_chair_wings_toppled"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "torncarpet12"},/area/f13/farmhouse)
+"aM" = (/obj/machinery/washing_machine,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aN" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aO" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "damaged1"},/area/f13/farmhouse)
+"aP" = (/obj/structure/chair/wood/wings{icon_state = "wooden_chair_wings"; dir = 8},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"aQ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "torncarpet2"},/area/f13/farmhouse)
+"aR" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "torncarpet9"},/area/f13/farmhouse)
+"aS" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aT" = (/obj/structure/sink/kitchen{pixel_y = 20},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aU" = (/obj/structure/barricade/wooden/crude{icon_state = "woodenbarricade-old"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 9},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aV" = (/obj/structure/sink/kitchen,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"aW" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"aX" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 4},/turf/open/floor/plastic,/area/f13/farmhouse)
+"aY" = (/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"aZ" = (/turf/open/floor/sepia,/area/f13/farmhouse)
+"ba" = (/obj/structure/table,/obj/effect/decal/cleanable/glass,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bb" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bc" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"bd" = (/obj/structure/chair/wood/wings{icon_state = "wooden_chair_wings"; dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"be" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "torncarpet11"},/area/f13/farmhouse)
+"bf" = (/turf/closed/wall/f13/wood/painted{icon_state = "wasteland12holes"},/area/f13/farmhouse)
+"bg" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"bh" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-middle"; dir = 1},/area/f13/farmhouse)
+"bi" = (/obj/structure/sink/kitchen{icon_state = "sink_alt"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bj" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "torncarpet15"},/area/f13/farmhouse)
+"bk" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bl" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bm" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 4},/turf/open/floor/sepia,/area/f13/farmhouse)
+"bn" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bo" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"bp" = (/obj/structure/fence{icon_state = "straight"; dir = 1},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"bq" = (/obj/structure/fence{icon_state = "straight"; dir = 8},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"br" = (/obj/item/chair/wood/wings,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bs" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"bt" = (/obj/structure/fence/door,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"bu" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 8},/turf/open/floor/sepia,/area/f13/farmhouse)
+"bv" = (/obj/structure/table,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bw" = (/obj/structure/fence/corner,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"bx" = (/obj/structure/closet/cabinet,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"by" = (/turf/open/floor/plating/ground/snow{icon_state = "snow2"},/area/f13/farmhouse)
+"bz" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 4},/obj/effect/decal/cleanable/blood/old,/obj/effect/decal/cleanable/blood/innards{pixel_x = 5; pixel_y = 5},/obj/effect/decal/cleanable/blood/gibs/core,/turf/open/floor/sepia,/area/f13/farmhouse)
+"bA" = (/obj/effect/decal/cleanable/dirt,/obj/structure/sink/kitchen{pixel_y = 20},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bB" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins6"},/area/f13/farmhouse)
+"bC" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins12alt"},/area/f13/farmhouse)
+"bD" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins10alt"},/area/f13/farmhouse)
+"bE" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins2alt"},/area/f13/farmhouse)
+"bF" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 4},/area/f13/farmhouse)
+"bG" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 8},/area/f13/farmhouse)
+"bH" = (/obj/effect/decal/cleanable/dirt,/obj/structure/dresser,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bI" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins3"},/area/f13/farmhouse)
+"bJ" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins4alt"},/area/f13/farmhouse)
+"bK" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins15"},/area/f13/farmhouse)
+"bL" = (/obj/structure/closet/cabinet,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bM" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"bN" = (/obj/structure/mirror{pixel_y = 35},/obj/structure/sink{pixel_y = 28},/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"bO" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 9},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bP" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"bQ" = (/obj/item/shard,/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 5},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bR" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 10},/turf/open/floor/wood/f13/old{icon_state = "torncarpet7"},/area/f13/farmhouse)
+"bS" = (/obj/structure/bed,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bT" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bU" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"bV" = (/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/obj/structure/sign/poster/ripped,/turf/closed/wall/f13/wood/painted{icon_state = "girder-middle"; dir = 8},/area/f13/farmhouse)
+"bW" = (/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"bX" = (/turf/open/floor/plating/ground/snow{icon_state = "snow3"},/area/f13/farmhouse)
+"bY" = (/obj/structure/closet/secure_closet/freezer/fridge,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"bZ" = (/obj/structure/table,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/space/basic,/area/f13/farmhouse)
+"ca" = (/turf/open/floor/plating/ground/snow,/obj/structure/barricade/wooden/crude{icon_state = "woodenbarricade-old"; dir = 8},/turf/closed/wall/f13/wood/painted{icon_state = "girder-b"; dir = 8},/area/f13/farmhouse)
+"cb" = (/obj/structure/bed,/obj/item/bedsheet,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cc" = (/obj/structure/bedsheetbin,/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cd" = (/obj/machinery/shower{pixel_y = 15},/obj/structure/curtain,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"ce" = (/obj/effect/decal/cleanable/blood/tracks{icon_state = "tracks"; dir = 8},/obj/effect/decal/cleanable/blood/splatter{pixel_y = 10},/turf/open/floor/sepia,/area/f13/farmhouse)
+"cf" = (/obj/effect/decal/cleanable/blood/tracks{icon_state = "tracks"; dir = 8},/turf/open/floor/sepia,/area/f13/farmhouse)
+"cg" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = 15},/obj/effect/decal/cleanable/blood/tracks{icon_state = "tracks"; dir = 5},/turf/open/floor/sepia,/area/f13/farmhouse)
+"ch" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = -15},/turf/open/floor/sepia,/area/f13/farmhouse)
+"ci" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins8"},/area/f13/farmhouse)
+"ck" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken1"},/area/f13/farmhouse)
+"cl" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = 15},/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/sepia,/area/f13/farmhouse)
+"cm" = (/obj/structure/sink{dir = 4; pixel_x = -12},/obj/structure/mirror{pixel_x = -30},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"cn" = (/turf/closed/wall/f13/wood,/area/f13/farmhouse)
+"co" = (/obj/structure/urinal{dir = 4; icon_state = "urinal"; pixel_x = -30},/turf/open/floor/sepia,/area/f13/farmhouse)
+"cp" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 8},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"cq" = (/turf/closed/wall/f13/wood{icon_state = "wood12"},/area/f13/farmhouse)
+"cr" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/stage_t,/area/f13/farmhouse)
+"cs" = (/turf/closed/wall/f13/wood{icon_state = "wood3"},/area/f13/farmhouse)
+"ct" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cu" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/sepia,/area/f13/farmhouse)
+"cv" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"},/area/f13/farmhouse)
+"cw" = (/obj/effect/turf_decal/weather/snow/corner,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 10},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cx" = (/obj/effect/turf_decal/weather/snow/corner,/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"cy" = (/obj/effect/decal/cleanable/glass,/obj/structure/table,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cz" = (/obj/structure/stairs/east{icon_state = "stairs"; dir = 2},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cA" = (/obj/effect/decal/cleanable/glass,/obj/structure/table,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cB" = (/obj/structure/table,/obj/machinery/reagentgrinder,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cC" = (/obj/effect/decal/cleanable/glass,/obj/structure/table,/obj/machinery/microwave{desc = "Cooks and boils stuff, somehow."; pixel_x = -3; pixel_y = 5},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cD" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins1alt"},/area/f13/farmhouse)
+"cE" = (/turf/closed/wall/f13/wood{icon_state = "wood6"},/area/f13/farmhouse)
+"cF" = (/turf/closed/wall/f13/wood{icon_state = "wood13"},/area/f13/farmhouse)
+"cG" = (/obj/effect/decal/cleanable/blood/tracks{icon_state = "tracks"; dir = 6},/turf/open/floor/sepia,/area/f13/farmhouse)
+"cH" = (/obj/structure/closet/secure_closet/freezer/fridge,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cI" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cJ" = (/turf/closed/wall/f13/wood{icon_state = "wood14"},/area/f13/farmhouse)
+"cK" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-middle"},/area/f13/farmhouse)
+"cL" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 1},/area/f13/farmhouse)
+"cM" = (/obj/structure/table,/obj/structure/showcase/machinery/microwave{name = "Microwave"},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cN" = (/obj/machinery/shower{icon_state = "shower"; dir = 1},/obj/structure/curtain,/obj/structure/lattice/catwalk{icon_state = "catwalk-nostripe-center"},/obj/structure/lattice/catwalk,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"cO" = (/obj/structure/dresser,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cP" = (/mob/dead/new_player,/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins4alt"},/area/f13/farmhouse)
+"cQ" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins1"},/area/f13/farmhouse)
+"cR" = (/turf/closed/wall/f13/wood{icon_state = "wood5"},/area/f13/farmhouse)
+"cS" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"cT" = (/turf/closed/indestructible/f13/matrix,/area/space)
+"cU" = (/obj/machinery/jukebox,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"cV" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins5"},/area/f13/farmhouse)
+"cW" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins14alt"},/area/f13/farmhouse)
+"cX" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"cY" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins9alt"},/area/f13/farmhouse)
+"cZ" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins7"},/area/f13/farmhouse)
+"da" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins8alt"},/area/f13/farmhouse)
+"db" = (/obj/item/reagent_containers/glass/bucket/wooden,/obj/structure/rack,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dc" = (/obj/machinery/shower{pixel_y = 15},/obj/structure/curtain,/obj/structure/lattice/catwalk{icon_state = "catwalk-nostripe-center"},/obj/structure/lattice/catwalk,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"dd" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins11alt"},/area/f13/farmhouse)
+"de" = (/obj/structure/fireplace,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"df" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins4"},/area/f13/farmhouse)
+"dg" = (/obj/effect/decal/cleanable/dirt,/turf/closed/wall/f13/wood/painted,/area/f13/farmhouse)
+"dh" = (/turf/closed/wall/r_wall/f13/composite{icon_state = "ruins9"},/area/f13/farmhouse)
+"di" = (/obj/structure/chair/stool/bar,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dj" = (/obj/structure/sink{dir = 8; icon_state = "sink"; pixel_x = 15},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"dk" = (/obj/effect/decal/cleanable/glass,/obj/machinery/light/small{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dl" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dm" = (/obj/machinery/light/small{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dn" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder"},/area/f13/farmhouse)
+"do" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood/painted{icon_state = "girder-middle"; dir = 8},/area/f13/farmhouse)
+"dp" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/item/shard,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dq" = (/obj/structure/closet/secure_closet/freezer/fridge,/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dr" = (/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"ds" = (/obj/structure/table,/obj/structure/showcase/machinery/microwave{name = "Microwave"},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 5},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dt" = (/obj/structure/table,/obj/effect/decal/cleanable/glass,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"du" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small,/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"dv" = (/obj/structure/bed,/obj/item/bedsheet,/obj/machinery/light/small{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dw" = (/turf/open/floor/plastic,/area/f13/farmhouse)
+"dx" = (/obj/structure/table,/obj/machinery/light/small{brightness = 3; dir = 8},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dy" = (/obj/effect/decal/cleanable/blood/tracks,/turf/closed/indestructible/f13/matrix,/area/f13/farmhouse)
+"dz" = (/obj/structure/barricade/wooden,/obj/structure/barricade/wooden/crude{icon_state = "woodenbarricade-old"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dA" = (/obj/structure/chair/office/light{icon_state = "officechair_white"; dir = 1},/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken1"},/area/f13/farmhouse)
+"dB" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken2"},/area/f13/farmhouse)
+"dC" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"dD" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dE" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/open/floor/plastic,/area/f13/farmhouse)
+"dF" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken1"},/area/f13/farmhouse)
+"dG" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken2"},/area/f13/farmhouse)
+"dH" = (/obj/structure/table,/obj/machinery/microwave{desc = "Cooks and boils stuff, somehow."; pixel_x = -3; pixel_y = 5},/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"dI" = (/obj/structure/closet/cabinet,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dJ" = (/obj/structure/chair/wood/wings{icon_state = "wooden_chair_wings"; dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dK" = (/obj/structure/closet/cabinet,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"dL" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/stage_tl,/area/f13/farmhouse)
+"dM" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{brightness = 3; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dN" = (/obj/effect/decal/cleanable/glass,/obj/structure/table,/obj/structure/showcase/machinery/microwave{name = "Microwave"},/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dO" = (/obj/structure/sink/kitchen{desc = "A sink used for washing one's hands and face. It looks rusty and home-made"; dir = 4; icon_state = "sink_alt"; name = "sink"; pixel_x = -10; pixel_y = 0},/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dP" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dQ" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 5},/turf/open/floor/wood/f13/stage_t,/area/f13/farmhouse)
+"dR" = (/obj/structure/table,/obj/machinery/light/small{dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dS" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dT" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dU" = (/obj/machinery/door/airlock/public,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"dV" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"dW" = (/obj/machinery/light{dir = 4},/turf/open/floor/sepia,/area/f13/farmhouse)
+"dX" = (/obj/machinery/light{dir = 8},/turf/open/floor/sepia,/area/f13/farmhouse)
+"dY" = (/obj/machinery/light{dir = 1},/turf/open/floor/sepia,/area/f13/farmhouse)
+"dZ" = (/obj/machinery/light,/turf/open/floor/sepia,/area/f13/farmhouse)
+"ea" = (/turf/closed/wall/f13/wood{icon_state = "wood9"},/area/f13/farmhouse)
+"eb" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ec" = (/obj/structure/barricade/wooden,/obj/structure/barricade/wooden/crude{icon_state = "woodenbarricade-old"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 10},/obj/effect/turf_decal/weather/snow/corner,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ed" = (/obj/effect/landmark/start/assistant,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"ee" = (/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_bottom"},/area/f13/farmhouse)
+"ef" = (/obj/structure/sink{dir = 8; pixel_x = 11},/turf/open/floor/plastic,/area/f13/farmhouse)
+"eg" = (/obj/effect/decal/cleanable/blood/tracks{icon_state = "tracks"; dir = 9},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"eh" = (/obj/effect/decal/cleanable/blood/tracks{icon_state = "tracks"; dir = 4},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"ei" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"ej" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ek" = (/turf/open/floor/wood/f13/old,/turf/closed/wall/f13/wood{icon_state = "girder-middle"; dir = 4},/area/f13/farmhouse)
+"el" = (/obj/effect/decal/cleanable/glass,/obj/item/shard,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"em" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/stage_l,/area/f13/farmhouse)
+"en" = (/obj/structure/table/wood,/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"eo" = (/obj/structure/chair/stool,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ep" = (/obj/structure/chair/stool/bar,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eq" = (/obj/structure/stairs/east,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"er" = (/obj/structure/table,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"es" = (/obj/structure/disposalpipe/trunk,/turf/closed/wall/f13/wood/painted,/area/f13/farmhouse)
+"et" = (/obj/structure/fireplace,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eu" = (/obj/structure/curtain,/obj/effect/decal/cleanable/dirt,/obj/machinery/shower{pixel_y = 15},/turf/open/floor/plastic,/area/f13/farmhouse)
+"ev" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ew" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"ex" = (/obj/structure/chair/wood/wings,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ey" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"ez" = (/obj/effect/decal/cleanable/glass,/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eA" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"eB" = (/obj/structure/table_frame/wood,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eC" = (/obj/structure/curtain,/obj/effect/decal/cleanable/dirt,/obj/machinery/shower{icon_state = "shower"; dir = 1},/turf/open/floor/plastic,/area/f13/farmhouse)
+"eD" = (/obj/machinery/light/small,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eE" = (/obj/machinery/light/small,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"eF" = (/obj/machinery/light{dir = 8},/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"eG" = (/obj/structure/closet/crate,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"eH" = (/obj/machinery/light/small{dir = 8},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eI" = (/obj/structure/closet/cardboard,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"eJ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"eK" = (/turf/open/floor/wood/f13/old{icon_state = "damaged1"},/area/f13/underground/vault_atrium_upper)
+"eL" = (/obj/effect/spawner/structure/window,/turf/open/floor/plasteel,/area/f13/underground/vault_atrium_upper)
+"eM" = (/obj/structure/fluff/railing{dir = 4; icon_state = "railing"; pixel_x = -30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"eN" = (/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"eO" = (/obj/structure/fluff/railing{dir = 8; icon_state = "railing"; pixel_x = 30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"eP" = (/turf/open/openspace,/area/f13/farmhouse)
+"eQ" = (/obj/structure/bed,/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"eR" = (/obj/effect/spawner/structure/window/reinforced,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"eS" = (/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"eT" = (/turf/open/floor/plasteel/f13/vault_floor/yellow,/area/f13/underground/vault_atrium_upper)
+"eU" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"eV" = (/obj/structure/stairs/east{icon_state = "stairs"; dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"eW" = (/turf/closed/wall/r_wall/f13/vault/reinforced,/area/space)
+"eX" = (/obj/structure/fluff/railing{dir = 1; icon_state = "railing"; pixel_y = -30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"eY" = (/obj/structure/window{dir = 4},/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/window{dir = 1},/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"eZ" = (/obj/effect/decal/cleanable/dirt,/obj/structure/toilet{icon_state = "toilet00"; dir = 4},/turf/open/floor/plastic,/area/f13/farmhouse)
+"fa" = (/obj/machinery/light/small{dir = 1},/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"fb" = (/obj/effect/decal/cleanable/dirt,/turf/closed/wall/f13/wood/painted{icon_state = "wood1"},/area/f13/farmhouse)
+"fc" = (/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"fd" = (/obj/effect/decal/cleanable/dirt,/obj/structure/bed,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"fe" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken1"},/area/f13/farmhouse)
+"ff" = (/obj/machinery/shower{icon_state = "shower"; dir = 1},/obj/structure/curtain,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plastic,/area/f13/farmhouse)
+"fg" = (/obj/effect/decal/cleanable/dirt,/turf/closed/wall/f13/wood/painted{icon_state = "wood2"},/area/f13/farmhouse)
+"fh" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old{icon_state = "housewood2-broken"},/area/f13/farmhouse)
+"fi" = (/obj/effect/decal/cleanable/glass,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"fj" = (/obj/effect/spawner/structure/window,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fk" = (/obj/structure/table/wood,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/machinery/computer/security/wooden_tv{desc = "An old Television. It doesn't look functional anymore. There probably wouldn't be any channels, anyways."; name = "Television"},/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"fl" = (/obj/machinery/light/small{dir = 4},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"fm" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/stage_t,/area/f13/farmhouse)
+"fn" = (/obj/structure/window{dir = 8},/obj/structure/flora/ausbushes/fullgrass,/obj/structure/window{dir = 1},/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fo" = (/turf/closed/indestructible/rock,/area/space)
+"fp" = (/obj/effect/turf_decal/weather/snow/corner,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/stage_l,/area/f13/farmhouse)
+"fq" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fr" = (/obj/structure/bed,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_z = 30},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fs" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_z = 30},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ft" = (/obj/structure/bed,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/item/bedsheet,/obj/structure/curtain/bounty{pixel_z = 30},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fu" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/fluff/bus/passable/seat{pixel_x = 6; pixel_y = 0},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fv" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/table/wood,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fw" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/item/chair/wood,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fx" = (/obj/structure/window{dir = 4},/obj/structure/flora/ausbushes/leafybush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/brflowers,/obj/machinery/door/window,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fy" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small{dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fz" = (/obj/structure/stairs/east,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"fA" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/chair/wood{icon_state = "wooden_chair"; dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fB" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/chair/wood{icon_state = "wooden_chair"; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fC" = (/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"fD" = (/obj/structure/table,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"fE" = (/obj/structure/stairs/east{icon_state = "stairs"; dir = 2},/turf/open/floor/plasteel/f13/vault_floor/yellow,/area/f13/underground/vault_atrium_upper)
+"fF" = (/obj/structure/fluff/railing{icon_state = "railing"; dir = 4},/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fG" = (/obj/structure/disposalpipe/trunk,/turf/closed/wall/f13/wood{icon_state = "wood12"},/area/f13/farmhouse)
+"fH" = (/obj/structure/table,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"fI" = (/obj/machinery/light{dir = 8},/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"fJ" = (/obj/structure/table,/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"fK" = (/obj/structure/stairs/east{icon_state = "stairs"; dir = 1},/turf/open/floor/plasteel/f13/vault_floor/yellow,/area/f13/underground/vault_atrium_upper)
+"fL" = (/turf/closed/indestructible/rock,/area/f13/underground/vault_atrium_upper)
+"fM" = (/obj/structure/window{dir = 4},/obj/structure/flora/ausbushes/lavendergrass,/obj/structure/flora/ausbushes/ywflowers,/obj/structure/window{dir = 1},/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fN" = (/obj/structure/table/wood/bar,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"fO" = (/obj/structure/window{dir = 8},/obj/structure/flora/ausbushes/stalkybush,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fP" = (/obj/structure/window{dir = 4},/obj/structure/flora/ausbushes/leafybush,/obj/machinery/door/window,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fQ" = (/obj/structure/window{dir = 4},/obj/structure/flora/ausbushes/brflowers,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fR" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fS" = (/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"fT" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_x = 30; pixel_z = 0},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"fU" = (/obj/structure/bookcase/random/religion{pixel_z = -10},/turf/closed/wall/f13/wood{icon_state = "wood12"},/area/f13/farmhouse)
+"fV" = (/obj/structure/bookcase/random,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"fW" = (/obj/machinery/light{dir = 4},/obj/structure/bookcase/random,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"fX" = (/obj/machinery/door/window,/obj/structure/window{dir = 8},/obj/structure/flora/ausbushes/reedbush,/obj/structure/flora/ausbushes/ppflowers,/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"fY" = (/obj/structure/fluff/railing{dir = 4; icon_state = "railing"; pixel_x = -30},/obj/structure/fluff/railing{dir = 1; icon_state = "railing"; pixel_y = -30},/obj/structure/fluff/railing/corner{dir = 4; icon_state = "railing_corner"; pixel_x = -30; pixel_y = -30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"fZ" = (/obj/structure/fluff/railing{dir = 8; icon_state = "railing"; pixel_x = 30},/obj/structure/fluff/railing{dir = 1; icon_state = "railing"; pixel_y = -30},/obj/structure/fluff/railing/corner{dir = 1; icon_state = "railing_corner"; pixel_x = 30; pixel_y = -30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"ga" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/sign/poster/ripped{pixel_y = 32},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gb" = (/obj/effect/spawner/structure/window,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"gc" = (/obj/machinery/light{dir = 4},/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"gd" = (/obj/effect/decal/cleanable/dirt,/obj/structure/bed,/obj/machinery/light/small{dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ge" = (/obj/machinery/door/airlock/public/glass,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/underground/vault_atrium_upper)
+"gf" = (/obj/effect/spawner/structure/window,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"gg" = (/obj/structure/chair/stool,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"gh" = (/obj/effect/decal/cleanable/dirt,/turf/closed/wall/f13/wood{icon_state = "wood12"},/area/f13/farmhouse)
+"gi" = (/obj/effect/decal/cleanable/dirt,/obj/structure/closet/cabinet,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gj" = (/obj/machinery/door/airlock/public/glass,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"gk" = (/obj/structure/table/wood/fancy,/turf/open/floor/plasteel/cafeteria,/area/f13/underground/vault_atrium_upper)
+"gl" = (/turf/closed/wall/r_wall/f13/vault/reinforced,/area/f13/farmhouse)
+"gm" = (/obj/effect/decal/cleanable/dirt,/obj/structure/chair/wood{icon_state = "wooden_chair"; dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gn" = (/obj/structure/fluff/railing{dir = 4; icon_state = "railing"; pixel_x = -30},/obj/structure/fluff/railing{pixel_y = 30},/obj/structure/fluff/railing/corner{pixel_x = -30; pixel_y = 30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"go" = (/obj/structure/fluff/railing{dir = 8; icon_state = "railing"; pixel_x = 30},/obj/structure/fluff/railing{pixel_y = 30},/obj/structure/fluff/railing/corner{dir = 8; icon_state = "railing_corner"; pixel_x = 30; pixel_y = 30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"gp" = (/obj/structure/window{dir = 8},/obj/structure/flora/ausbushes/ywflowers,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"gq" = (/obj/structure/fluff/railing{dir = 1; icon_state = "railing"; pixel_y = -30},/obj/structure/fluff/railing{dir = 4; icon_state = "railing"; pixel_x = -30},/obj/structure/fluff/railing/corner{dir = 4; icon_state = "railing_corner"; pixel_x = -30; pixel_y = -30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"gr" = (/obj/structure/window{dir = 4},/obj/structure/flora/ausbushes/brflowers,/obj/structure/flora/ausbushes/sparsegrass,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"gs" = (/obj/machinery/door/window,/obj/structure/window{dir = 8},/obj/structure/flora/ausbushes/reedbush,/obj/structure/flora/ausbushes/ppflowers,/turf/open/floor/plating/grass,/area/f13/underground/vault_atrium_upper)
+"gt" = (/obj/structure/fluff/railing{dir = 1; icon_state = "railing"; pixel_y = -30},/obj/structure/fluff/railing{dir = 8; icon_state = "railing"; pixel_x = 30},/obj/structure/fluff/railing/corner{dir = 1; icon_state = "railing_corner"; pixel_x = 30; pixel_y = -30},/turf/open/openspace,/area/f13/underground/vault_atrium_upper)
+"gu" = (/obj/effect/spawner/structure/window,/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"gv" = (/obj/effect/decal/cleanable/dirt,/obj/structure/bed,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gw" = (/turf/open/water,/area/f13/farmhouse)
+"gx" = (/turf/open/openspace,/area/space)
+"gy" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_z = -30},/obj/structure/table/wood,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gz" = (/turf/closed/wall/r_wall/f13/vault/reinforced,/area/f13/underground/vault_atrium_upper)
+"gA" = (/obj/machinery/power/smes/magical,/obj/structure/cable,/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"gB" = (/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/glass,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_z = -30},/obj/structure/chair/wood{icon_state = "wooden_chair"; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gC" = (/turf/closed/wall/r_wall,/area/f13/farmhouse)
+"gD" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_z = -30},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gE" = (/obj/machinery/power/smes/magical,/obj/structure/cable,/turf/open/floor/plasteel,/area/f13/farmhouse)
+"gF" = (/obj/structure/cable,/obj/machinery/power/terminal{dir = 8},/turf/open/floor/plasteel,/area/f13/farmhouse)
+"gG" = (/obj/effect/turf_decal/tile/neutral{dir = 1},/obj/effect/turf_decal/tile/neutral,/obj/effect/turf_decal/tile/neutral{dir = 4},/obj/effect/turf_decal/tile/neutral{dir = 8},/obj/effect/turf_decal/bot{dir = 1},/obj/structure/cable,/obj/machinery/light/small{brightness = 3; dir = 8},/obj/machinery/power/apc{areastring = "/area/engine/engine_smes"; dir = 1; name = "SMES room APC"; pixel_y = 23},/turf/open/floor/plasteel/dark,/area/f13/farmhouse)
+"gH" = (/obj/structure/cable,/obj/machinery/power/terminal{dir = 8},/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"gI" = (/obj/structure/cable,/obj/machinery/light/small{brightness = 3; dir = 8},/obj/machinery/power/apc{areastring = "/area/engine/engine_smes"; dir = 1; name = "SMES room APC"; pixel_y = 23},/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/f13/underground/vault_atrium_upper)
+"gJ" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/dresser,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gK" = (/obj/effect/decal/cleanable/dirt,/obj/structure/curtain,/obj/machinery/shower{pixel_y = 15},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gL" = (/obj/effect/decal/cleanable/dirt,/obj/structure/toilet{icon_state = "toilet00"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gM" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/structure/curtain/bounty{pixel_z = -30},/obj/effect/decal/cleanable/glass,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gN" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/glass,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gO" = (/obj/machinery/light/small{dir = 4},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 6},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gP" = (/obj/structure/table,/obj/effect/decal/cleanable/glass,/obj/machinery/chem_dispenser/drinks/beer{icon_state = "booze_dispenser"; dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gQ" = (/obj/structure/table,/obj/machinery/chem_dispenser/drinks{icon_state = "soda_dispenser"; dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gR" = (/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 9},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gS" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 10},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gT" = (/obj/effect/decal/cleanable/dirt,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_surround"; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gU" = (/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gW" = (/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_surround"; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gX" = (/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_surround"; dir = 2},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"gY" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 9},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_left"},/area/f13/farmhouse)
+"gZ" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 5},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_top_right"},/area/f13/farmhouse)
+"ha" = (/obj/effect/decal/cleanable/glass,/obj/structure/barricade/wooden/snowed,/obj/structure/barricade/wooden/crude,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hb" = (/obj/structure/table,/obj/machinery/microwave{desc = "Cooks and boils stuff, somehow."; pixel_x = -3; pixel_y = 5},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hc" = (/obj/effect/decal/cleanable/dirt,/obj/structure/dresser,/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"hd" = (/obj/effect/decal/cleanable/dirt,/obj/structure/easel,/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"he" = (/obj/effect/decal/cleanable/dirt,/obj/structure/easel,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken1"},/area/f13/farmhouse)
+"hf" = (/obj/effect/decal/cleanable/dirt,/obj/structure/easel,/turf/open/floor/wood/f13/old{icon_state = "housewood2-broken"},/area/f13/farmhouse)
+"hg" = (/turf/open/floor/plastic,/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 4},/area/f13/farmhouse)
+"hh" = (/obj/structure/bookcase/manuals/medical,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hi" = (/obj/structure/fluff/paper,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hj" = (/turf/open/floor/plastic,/turf/closed/wall/f13/wood/painted{icon_state = "girder"},/area/f13/farmhouse)
+"hk" = (/obj/structure/table/wood,/obj/item/paper_bin,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hl" = (/obj/machinery/iv_drip,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hm" = (/obj/structure/chair/wood/wings{dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hn" = (/obj/structure/table/wood,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"ho" = (/obj/structure/chair/wood/wings{icon_state = "wooden_chair_wings"; dir = 8},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hp" = (/obj/structure/sink{dir = 4; pixel_x = -12},/turf/open/floor/plastic,/area/f13/farmhouse)
+"hq" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 8},/turf/open/floor/plastic,/area/f13/farmhouse)
+"hr" = (/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hs" = (/obj/structure/curtain,/obj/structure/window/f13{icon_state = "window"; dir = 1},/obj/structure/windoor_assembly{icon_state = "l_windoor_assembly01"; dir = 4},/obj/machinery/shower{dir = 1; icon_state = "shower"; pixel_y = -2},/turf/open/floor/plastic,/area/f13/farmhouse)
+"ht" = (/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 4},/area/f13/farmhouse)
+"hu" = (/obj/effect/landmark/observer_start,/turf/open/floor/plating/ice/colder,/area/f13/farmhouse)
+"hv" = (/obj/structure/table/wood,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/obj/item/flashlight/lamp,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hw" = (/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/turf/closed/wall/f13/wood/painted{icon_state = "girder-end"; dir = 8},/area/f13/farmhouse)
+"hy" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_left"},/area/f13/farmhouse)
+"hz" = (/obj/effect/decal/cleanable/glass,/obj/structure/table/wood,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old{icon_state = "torncarpet4"},/area/f13/farmhouse)
+"hA" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"hB" = (/obj/structure/chair/wood/wings,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hC" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow7"},/turf/open/floor/plating/ground/snow,/area/f13/farmhouse)
+"hD" = (/obj/structure/sink{dir = 8; pixel_x = 11},/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hE" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/stage_tr,/area/f13/farmhouse)
+"hF" = (/turf/open/floor/wood/f13/old{icon_state = "carpet"},/area/f13/farmhouse)
+"hG" = (/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken2"},/area/f13/farmhouse)
+"hI" = (/turf/open/floor/wood/f13/old{icon_state = "damaged1"},/area/f13/farmhouse)
+"hJ" = (/turf/open/floor/wood/f13/old{icon_state = "torncarpet2"},/area/f13/farmhouse)
+"hL" = (/turf/open/floor/wood/f13/old{icon_state = "torncarpet15"},/area/f13/farmhouse)
+"hM" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_surround"; dir = 8},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hN" = (/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken1"},/area/f13/farmhouse)
+"hO" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hP" = (/obj/effect/decal/cleanable/glass,/obj/structure/barricade/wooden/snowed,/obj/structure/barricade/wooden/crude,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hQ" = (/obj/structure/sign/poster/official/wtf_is_co2{pixel_y = 32},/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hR" = (/obj/structure/sign/poster/official/fruit_bowl,/turf/closed/wall/f13/wood/painted,/area/f13/farmhouse)
+"hS" = (/obj/structure/chair/wood/wings,/turf/open/floor/wood/f13/old{icon_state = "housewood3-broken2"},/area/f13/farmhouse)
+"hT" = (/obj/structure/table/wood,/obj/structure/sign/poster/official/work_for_a_future{pixel_y = -32},/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hU" = (/obj/effect/spawner/structure/window,/obj/structure/barricade/wooden/crude,/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hV" = (/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner,/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hW" = (/obj/effect/turf_decal/weather/snow/corner,/obj/structure/chair/wood/wings{dir = 1},/turf/open/floor/wood/f13/old{icon_state = "housewood2"},/area/f13/farmhouse)
+"hX" = (/obj/structure/table/wood,/obj/item/clipboard,/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_surround"; dir = 8},/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hY" = (/obj/structure/table/wood,/obj/effect/decal/cleanable/glass,/obj/effect/turf_decal/weather/snow/corner{icon_state = "gravsnow_corner"; dir = 8},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"hZ" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 6},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_right"},/area/f13/farmhouse)
+"ia" = (/obj/effect/turf_decal/weather/snow/corner,/turf/open/floor/wood/f13/stage_b,/area/f13/farmhouse)
+"ib" = (/obj/effect/turf_decal/weather/snow/corner,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_bottom_right"},/area/f13/farmhouse)
+"ic" = (/turf/open/floor/plasteel/f13/vault_floor/blue/white,/area/space)
+"id" = (/turf/open/floor/wood/f13/stage_b,/area/f13/farmhouse)
+"ie" = (/obj/structure/closet/crate/medical,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"if" = (/obj/structure/chair/office/light,/obj/effect/decal/cleanable/glass,/obj/structure/fluff/paper/stack,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"ig" = (/obj/structure/table/wood,/obj/structure/fluff/paper/stack,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"ih" = (/obj/structure/bookcase/manuals/medical,/obj/structure/fluff/paper/corner,/turf/open/floor/plasteel/grimy,/area/f13/farmhouse)
+"ii" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 5},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ij" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 6},/turf/open/floor/wood/f13/old{icon_state = "housewood1-broken"},/area/f13/farmhouse)
+"ik" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 9},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"il" = (/obj/item/chair/wood,/obj/machinery/light/small{dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"im" = (/obj/structure/chair/wood/wings,/obj/machinery/light/small{dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"in" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 1},/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 5},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_top_right"},/area/f13/farmhouse)
+"io" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/old,/area/f13/farmhouse)
+"ip" = (/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 4},/turf/open/floor/wood/f13/old{icon_state = "housewood_stage_right"},/area/f13/farmhouse)
+"iq" = (/obj/effect/turf_decal/weather/snow/corner,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 8},/turf/open/floor/wood/f13/stage_b,/area/f13/farmhouse)
+"ir" = (/obj/structure/toilet{icon_state = "toilet00"; dir = 1},/obj/effect/decal/cleanable/dirt,/obj/machinery/light/small,/obj/effect/turf_decal/weather/snow/corner{icon_state = "snow_corner"; dir = 10},/turf/open/floor/plastic,/area/f13/farmhouse)
+"is" = (/turf/open/floor/plastic,/turf/closed/wall/f13/wood/painted{icon_state = "girder-middle"; dir = 8},/area/f13/farmhouse)
 
 (1,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababadaeaeadaeajhaaeadabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacacacacacacacacacac
+aaabababababababababababauaXefauhlbPbPeQhaabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacacacacacacacacacac
+aaabababababababababababauhsdwauapdrdrhvhaabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacacacacacacacac
+aaabababababababadhahahaadhgdwhjaeaedraeadabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacacacacacacacac
+aaabababababababauaEfkhzhFazhGdrdrdrdrdrauabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacac
+aaabababababababauaIhIhFhFhJhGdrdrdrapdraqhCababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacac
+aaabababababababaubRhFhFhLhGdrdrdrdrdrfHauabhCabababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacac
+aaabababababababadhtbVhwaddrdrdrdrhNhGhDhaababhCababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacac
+aaabababababababhMdrdrdrdrhiapdrdrapfifHauabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacac
+aaabababababababdgaeaeaeaYaeaddrdrhbfHfHauabababababababababababababababababababababababababababaaacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacacacacacac
+aaabababababababhPhXhQaYaYieaudrdrhRaeaeadabababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofofogzgzgzgzgzgzgzgzgzeWeWeWeWeWeWeWeWfofofofofofofofo
+aaabababababababhPhYifhkaYhhauhNhShBhBdrauabababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofofogzcXeSeTeTeTeSeUgzfCfDfDfDbYdHfDgzfofofofofofofofo
+aaabababababababhPhOhTigaYihauhmhnhnhnhohUabababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofofogzeYeSeTeTeTeSfngzfIfCfCfCfCfCfJgzfofofofofofofofo
+aaabababababababadaeadaedwaeadfihVhWhrapauabababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofofogzfQeSeTeTeTeSfOgzfCfNfNfNfNfNfNgzfofofofofofofofo
+aaabababababababababauhpdwhqauaehahahUaeadabababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofofogzfxeSeTeTeTeSfXgzfCfCfCfCfCfCfCgzfofofofofofofofo
+aaabababababababababauhsdwdwauabababababababababababababababababababababababababababababababababaacTacacacacacacacacfofofofofofogzgzgzgzgzgzgzgzgzgzgzgzcXeSeTeTeTeSeUgzfCfCfCfCfCfCfCgzfofofofofofofofo
+aaabababababababababadaeaeaeadabababababababababababababababababababababababababababababababababaaaaacacacacacacacacfofofofofofogzdKfSfSdUfSfSerfVfVfWgzeSeSfEfEfEeSeSgzfIfCfCfCfCfCgcgzfofofofofofofofo
+aaabababababababababababababababababababababababababababababababababababababababababababababglglgCaaacacacacacacacacfofofofofofogzfSfSfSgzeFfSerfSfSfSgbeSeSgzgzgzeSeSgffCggggggggggfCgzfofofofofofofofo
+aaabababababaBababadaeanaeadabababababababadaeafagagahadababababababababababababababababababgEgFgGaaacacacacacacacacfofofofofofogzfSfSeGgzfSfSerfSfVfSgeeSeSeTeTeTeSeSgjfCgkgkgkgkgkfCgzfofofofofofofofo
+aaabababababcaagahaubLaoaDauabababababababaUaGaVbTdqdsauabababababababababababababababababababababaaacacacacacacacacfofofofofofogzeGfSeIgzfSererfSfVfSgeeSeSeTeTeTeSeSgjfCggggggggggfCgzfofofofofofofofo
+aaababenawaxayaAaKauaCaCaCauabababababababdzaCaCaGaCaSaHcrfmaJfmhEababababababababababababababababaaacacacacacacacacfofofofofofogzerfSeIgzeFeKfSfSfSfSgbeSeSgzgzgzeSeSgffCgggggggggggcgzfofofofofofofofo
+aaababenaLaOaPaQaCaCaCaCaiauabababababababecaRaWaAdGaNaucwapaFcxhZababababababababababababababababaaacacacacacacacacfofofofofofogzeGfSeIgzfVfVfVfVfVfWgzeSeSfKfKfKeSeSgzfIgkgkgkgkgkfCgzfofofofofofofofo
+aaababcvbebgbjaCbbadaeanaeaeadababababababaHbobcazdGctadbfaFaFaeadababababababababababababababababaaacacacacacacacacfofofofofofogzgzgzgzgzgzgzgzgzgzgzgzcXeSeTeTeTeSeUgzfCggggggggggfCgzfofofofofofofofo
+aaababbhcIblaCaCaCaoaCaoaCdbaHababababababaubdbdaAdGaCaCaoaCaCiicvababababababababababababababababaaacacacacacacacacfofofofofofofofofofofofofofofofofogzeSeSeTeTeTeSeSgzgzgzgzgzgzgzgzgzfofofofofofofofo
+aaababbhataCaCbradaeaeaFaeaeadababababababauaCaCaCaCaCaGaCaCaCijcLabababbBbCbCbCbCbCbCbDabababababaaacacacacacacacacfofofofofofofofofofofofofofofofofogzeSeSeTeTeTeSeSgzfLfLfLfLfLfLfLfLfofofofofofofofo
+aaababcLasdpaCaChAikilaFimebinababababababadbFaCbGadbsadaeaebfaeadabababbIdrdrdrdrdrdrbIabababababaaacacacacacacacacfofofofofofofofofofofofofofofofofogzeSeSeTeTeTeSeSgzfofofofofofofofofofofofofofoacac
+aaababaudtbabvbihAioaFaFaFaFipababababababaubxaCdlaubMbNauabababbpabababbIdrdrdrdrdrdrbIabababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzcXeSeTeTeTeSeUgzfofofofofofofofofofofofofofoacac
+aaababadbnbnbnaFadiqiaididiaibababababababauaCdubSauireCauabababbpabababbIdrdrdrdrdrdrbIabababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzfMeSeTeTeTeSfngzfofofofofofofofofofofofofofoacac
+aaababababababababababababababababababababadaeaeaeadisaeadbqbtbqbwabababbIdrdrdrdrdrdrbIabababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzgreSeTeTeTeSgpgzfofofofofofofofofofofofofofoacac
+aaabababababababababababababababababababababababababbyabababababababababdrdrdrdrdrdrdrbIabababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzfPeSeTeTeTeSgsgzfofofofofofofofofofofofofofoacac
+aaababadaebfanaeaeadababababababababababababababababababababababababababbIdrdrdrdrfzdrbIabababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzcXeSeTeTeTeSeUgzfofofofofofofofofofofofofofoacac
+aaababbnbHaobkbUcbbnababababababababababababababababababababababababababcVbCbCbCbCbCbCcYabababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzeSeSeTeTeTeSeSgzfofofofofofofofofofofofofofoacac
+aaababbnblbkbkbkccbnabababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzeSeSeTeTeTeSeSgzfofofofofofofofofofofofofofoacac
+aaababadaeaeadbkadadabababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacacfofofofofofofofofofofofofogzgzgzgzgzgzgzgzgzfofofofofofofofofofofofofofoacac
+aaababaucddEbMaCalauabababababababababababababababababababababababababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacac
+aaababaucmcpauaCamaubWabababababababababababdLdQadaeaeejejebejaeadababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacac
+aaababadaeaeadaCaCaCababababababababababababemflaudMaCbAcAcBcHdNauababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacac
+aaababcvaCaCaCaCaCauabbXababababababababababemaFaCaCaCaCaGaCaCaNauababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacac
+aaababbhdOaCaCaCdPauababababababababababababfpgOaudMaCaCaCbkbkbZcvababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacac
+aaababcLaNcHcyarcCauababababababababababadaeejaeadaCaCcUaCckdGbkcKababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacac
+aaababdnaebnelbnaeadababababababababababaudldSbSaudMaCaudTaCaCaCcKababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacac
+aaabababababababababababababababababababgRdAdBaGauaCaCauaCdCdDdDcLababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofoacacacac
+aaabababababababababababababababababababgSbldFdGaCaCczaudTalalamauababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofoacacacacacacacacacacacacacacacacacacac
+aaabababababababababcncqeJcqcnabababababaudIdVcOauaCdgauaGdJdJdJauababababababababababababababababaaacacacacacacacacacacacfofofofofofofofofofofofofofofofofofofofoacacacacacacacacacacacacacacacacacacac
+aaabababababababababgTaCaCaMcsabababababadaeaeaeadaeaeaedodobGaeadababababababababababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababcsaCaCaGcsabababababababababababababababababababbBbCbCbCbCbCbCbCbCbCbCbCbDababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabcEbOgUgUgUbQcqcqcFcqaCcqcFejejejcJabababababababababababababbEaZbIaZaZaZaZdWbIdXaZaZaZaZbIaZbEaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabgWgPaTcHcMbvdkaCaCbkaCdmcsaCaCdlcsabababababababababababababbIdWcDaZcNcNcNcNbIcNcNcNcNaZcDdXbIaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabejgQblaCaGaCaCaCaCaCaCaCaCaCaCdvcsabababababababababababababbIaZaZdWcPbCbCbCbKbCbCbCcidXaZaZbIaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabejesdxaNdReseHaCaCaCaCaCcRaCaCaCcsabababababababababababababbIdWbEaZdcdcdcdcbIdcdcdcdcaZbEdXbIaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabcsdedieoepetaCaCaCaCaGaCeqcseDbxcsabababababababababababababcDaZbIaZaZaZaZdWbIdXaZaZaZaZbIaZcQaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabejaFaCaCbkbkbkaCaCaCaCaCcEcqcqcqcsabababababababababababababababcVcWbCbCbCbCbKbCbCbCbCcWcYababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabejevewexexbkaCbkeyeyeyaCcscSbMeucsababababababababababababababababbIbmaZaZaZbIaZaZaZbubIabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabgWezezeAeBaCeDaCeyeyeyeDdwbMeEdjcsabababababedededededababababababcZbCdadXaZbIaZdWbJbCddabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabekgXejejejcqcqcncqaFaFcqcncqcqcqeaababababababakakakakakakababababbIbmaZaZaZbIaZaZaZbubIabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaababababababababgYebaFaFebgZabababababababakakakavhuavavavavakakababcZbCcidXaZbIaZdWbJbCddabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaababababababababhyaFapaFaFhAababababakakakakavgwgwgwgwgwgwgwavakakabbIbzcecfcgbIchaZaZbubIabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaababababababababcneeeeeeeecnabababababakakakavavgwgwgwgwgwgwavakababcZbCdadXclbIchdWdfbCddabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaababababababababababababababababababababakakakakavavavavavakakakababbIcodYaZclbIchaZaZbubIabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaababababababababababababababababababababababakakakakakakakakakabababbIcoaZaZclbIchdWbJbCddabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababakakakakakababababbIcodZaZcubIaZaZaZbubIabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababakakabababababcVbCbCcicucDaZbJbCbCdhabababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababegehcfcGaZaZaZababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababeiabbCbCbCbCbCababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaabababababababababababababababababababababababababababababababababababeiababbyabababababababababaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaadyaaaaaaaaaaaaaaaaaaaaaaaaaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
 "}
-(2,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
+
+(1,1,2) = {"
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+gxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzgzgzgzgzgzgzgzgzgzgzgzgzfofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeSeTeTeTeSeSeSeSgzfofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeSeTeTeTeSeSeSeSgzfofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzgzeSgzgzeLeLeLgzgzeSgzgzfofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeMeNeNeNeOeSeSeSgzfofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeMeNeNeNeOeSeSeSgzfofofofofofofofofofogxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeMeNeNeNeOeSeSeSgzgzgzgzgzgzgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofoeWeWeWeWeWeWeWeWeWeWeWeWgzcXeSeSeMeNeNeNeOeSeSeUgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxfofoiciciciciciciciciciciciceSeSeSeSeMeNeNeNeOeSeSeSgueSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofoiciciciciciciciciciciciceSeSeSeSeMeNeNeNeOeSeSeSeSeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofoiciciciciciciciciciciciceSeSeSeSfYeTeTeTfZeSeSeSgueSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofoeWeWeWeWeWeWeWeWeWeWeWeWgzcXeSeSeSeTeTeTeSeSeSeUgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeSeTeTeTeSeSeSeSgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSgneTeTeTgoeSeSeSgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeMeNeNeNeOeSeSeSgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzcXeSeSeMeNeNeNeOeSeSeUgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeMeNeNeNeOeSeSeSgzeSeSeSeSeSgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePbBbCbCeReRbCbCbDePePePePePePgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofogzeSeSeSeMeNeNeNeOeSeSeSgzgzgzgzgzgzgzfofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePbIdrdrdrdrdrdrbIePePePePePePgxgxgxgxgxgxgxgxgxgxgxfofofofofofogzgzgzgzgzgzgzeSeSeSeMeNeNeNeOeSeSeSgzfofofofofofofofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePbIdrdrdrdrdrdrbIePePePePePePgxgxgxgxgxgxgxgxgxgxgxfofofofofofogzgAgHgIeSeSgzcXeSeSeMeNeNeNeOeSeSeUgzeWeWeWeWeWeWeWeWeWfofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePeRdrdrdrdrdrdreRePePePePePePgxgxgxgxgxgxgxgxgxgxgxfofofofofofogzeSeSeSeSeSgueSeSeSeMeNeNeNeOeSeSeSeSicicicicicicicicicfofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePeRdrdrdrdrdrdreRePePePePePePgxgxgxgxgxgxgxgxgxgxgxfofofofofofogzeSeSeSeSeSeSeSeSeSeMeNeNeNeOeSeSeSeSicicicicicicicicicfofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePbIdrdrdrdrdreVbIePePePePePePgxgxgxgxgxgxgxgxgxgxgxfofofofofofogzeSeSeSeSeSgueSeSeSeMeNeNeNeOeSeSeSeSicicicicicicicicicfofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePbIdrdrdrdrePdrbIePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofogzeSeSeSeSeSgzcXeSeSeMeNeNeNeOeSeSeUgzeWeWeWeWeWeWeWeWeWfofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePcVbCbCeReRbCbCcYePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofogzgzgzgzgzgzgzeSeSeSgqeXeXeXgteSeSeSgzfofofofofofofofofofofofogxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofogzeSeSeSeSeTeTeTeSeSeSeSgzfofofofofofogxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofogzeSeSeSeSeTeTeTeSeSeSeSgzfofofofofofogxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofogzgzgzgzgzgzgzgzgzgzgzgzgzfofofofofofogxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePadaeaeaeadaeaeaeaeaeaeaeadePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePaueZfabMbMaCaoaCfbhcfcfdauePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePaubMbMbMaudMaCfebebgbgbgauePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePauffbMdjauaCaCaCdgfgfgfgauePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePadaeanaeadaCaCaCaCaCaoaCcvePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePauhdaoheaufhaCaCaCaCaCaCcKePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePaFaCaCaCaudMaCaCaCaCfhaCcKePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePaFfhaCaCaCaCePaCaCaCaCaCcLePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxfofofofofofofofofofofofofofofofofofofogxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePaFaFePePePePePePePePauhddVhfauaCdVaCaCaCdVaCauePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePaFaFaFePePePePePePePadaeaeaeaeaeaedododobGaeadePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePaFaFaFaFePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcEbnbnfjcqfjfjbncqcqcqcqcqcqcqcqcJePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsaCfqfrcsaCfsftcsaCfufvfwfyaCaCcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsdMaCdPcscIfRbbcscIfAfvfBbkfRfTfjePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsaCaCbHcsaCaCbHcsbkbkbkbkaCaCfTbnePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcncqaCcqcncqaCcqeaaCaCfFePdVaCblcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsbkbkbkbkaCbkbkbkaCaCcEcqcqaCcqcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsfGcqbkfUfUcqcJaCbkbbcsbHaobkgvcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsetgabkbkbkgvcsaCaCaCcsaCaCaCaCcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcscIbkbkbkblgdcEcqaCghcJcqcqcqcqeaePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcsgigmgygBgDgJcsbkaCfygKcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePcRcqbnbnfjfjcqcsgLgDgMgNcsePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePcRcqfjfjbneaePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
+ePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePePgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgxgx
 "}
-(3,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(4,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(5,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(6,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(7,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(8,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(9,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(10,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(11,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(12,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(13,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(14,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(15,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(16,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(17,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(18,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(19,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(20,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(21,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(22,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(23,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(24,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(25,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(26,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(27,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(28,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(29,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(30,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(31,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(32,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(33,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(34,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(35,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(36,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(37,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(38,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(39,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(40,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(41,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(42,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(43,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(44,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(45,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(46,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(47,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(48,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(49,1,1) = {"
-a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-a
-"}
-(50,1,1) = {"
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
-a
+
+(1,1,3) = {"
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
+acacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacac
 "}

--- a/_maps/sunnydale.json
+++ b/_maps/sunnydale.json
@@ -3,6 +3,7 @@
     "map_path": "map_files/SunnyDale",
     "map_file": "SunnyDale.dmm",
 	"shuttles": {
-	    "cargo": "cargo_delta"
-    }
-}
+	    "cargo": "cargo_delta" 
+    },
+	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Up" : 1, "Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}]
+	}


### PR DESCRIPTION
MultiZ code in the modified Sunnydale.json file. As well as a few buildings meant for "Aspen"

The code making Multi-Z Function is provided in the sunnydale.json file i've modified. The line of coding making it possible being: 	"traits": [{"Up" : 1, "Linkage" : "Cross"}, {"Up" : 1, "Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}, {"Down" : -1, "Baseturf" : "/turf/open/openspace", "Linkage" : "Cross"}]

and is currently set to support up to three Z-levels. We will later on have to figure out if this affects performance and if it is, how much, and if it's possible to use multi-z only on certain Z-levels if so.