### PR TITLE
Atmos, lighting, and mineral gen fixes

### DIFF
--- a/code/game/turfs/open/floor/plating/dirt.dm
+++ b/code/game/turfs/open/floor/plating/dirt.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/turf/floors.dmi'
 	icon_state = "dirt"
 	baseturfs = /turf/open/chasm/jungle
-	initial_gas_mix = OPENTURF_LOW_PRESSURE
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
 	planetary_atmos = TRUE
 	attachment_holes = FALSE
 	footstep = FOOTSTEP_SAND

--- a/fallout/areas/area.dm
+++ b/fallout/areas/area.dm
@@ -10,7 +10,6 @@
 	outdoors = TRUE
 	has_gravity = STANDARD_GRAVITY
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
-	lightswitch = FALSE //no. just no
 	ambientsounds = list('fallout/sound/f13ambience/wasteland.ogg', 'fallout/sound/f13ambience/sewer.ogg')
 	flags_1 = NONE //>desert >>has destroyed robo dirt on it
 
@@ -44,7 +43,6 @@
 	power_environ = FALSE
 	power_equip = FALSE
 	outdoors = TRUE
-	lightswitch = FALSE //no. just no
 	flags_1 = NONE //>desert >>has destroyed robo dirt on it
 
 /area/f13/sunny_dale

--- a/fallout/turfs/minerals.dm
+++ b/fallout/turfs/minerals.dm
@@ -3,3 +3,6 @@
 	icon_state = "rock_lowchance"
 	baseturfs = /turf/open/floor/plating/ground/mountain
 	environment_type = "waste"
+	mineralSpawnChanceList = list(/obj/item/stack/ore/uranium = 5, /obj/item/stack/ore/diamond = 1, /obj/item/stack/ore/gold = 10,
+		/obj/item/stack/ore/silver = 12, /obj/item/stack/ore/plasma = 20, /obj/item/stack/ore/iron = 40, /obj/item/stack/ore/titanium = 11,
+		/turf/closed/mineral/gibtonite = 4, /obj/item/stack/ore/bluespace_crystal = 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -248,6 +248,7 @@
 #include "code\controllers\subsystem\blackmarket.dm"
 #include "code\controllers\subsystem\chat.dm"
 #include "code\controllers\subsystem\communications.dm"
+#include "code\controllers\subsystem\daynight.dm"
 #include "code\controllers\subsystem\dbcore.dm"
 #include "code\controllers\subsystem\dcs.dm"
 #include "code\controllers\subsystem\demo.dm"


### PR DESCRIPTION
<!-- HEY LISTEN!!! -->

<!-- WHEN MAKING A NEW PR TO THIS GIT, BE ABSOLUTELY SURE THE BASE REPO YOU'RE COMMITING TO ISN'T tgstation/tgstation IT SHOULD BE RobustTeam/tg-ashcloud -->

<!-- In edition changelogs won't be ultilized due to the way pulling from upstream tg will heavily filter out the old ones; instead change the changelog on the discord if we ever make one -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Dirt turfs should stop choking people due to the initial_gas_mix.
Light bulbs should stay on indefinitely (doesn't fix power issues with other machines).
Rock/mineral walls should stop generating random caves/tunnels.
Daynight subsystem wasn't turned on for some reason.

Please do note there are still some issues with daynight due to multi-z (openspace doesn't respect the lighting below it) which will need to be fixed later.

Gravity issues are simply fixed by adding areas properly to every turf, that is a mapping problem.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Maps should now be more playable than before.
Full-scale testing should soon be possible.