### PR TITLE
Removed space tiles and sign-backing (map fixes)

### DIFF
--- a/_maps/map_files/Mammoth/Mammoth.dmm
+++ b/_maps/map_files/Mammoth/Mammoth.dmm
@@ -9,16 +9,6 @@
 /obj/machinery/door/airlock/hatch,
 /turf/open/floor/plasteel/f13/vault_floor/dark,
 /area/f13/underground/mountain)
-"aad" = (
-/obj/structure/fence{
-	icon_state = "straight";
-	dir = 8
-	},
-/obj/item/sign_backing{
-	icon_state = "explosives2"
-	},
-/turf/open/floor/plating/ground/snow,
-/area/f13/desert)
 "aae" = (
 /turf/closed/mineral/random/f13,
 /area/f13/underground/mountain)
@@ -2673,12 +2663,6 @@
 	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/cafeteria,
 /area/f13/klamat)
-"ajo" = (
-/obj/item/sign_backing{
-	icon_state = "restroom"
-	},
-/turf/closed/wall/rust,
-/area/f13/klamat)
 "ajq" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /turf/closed/mineral/random/f13,
@@ -2983,9 +2967,6 @@
 "akP" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/structure/grille,
-/obj/item/sign_backing{
-	icon_state = "bluecross2"
-	},
 /turf/open/floor/plasteel/f13/vault_floor/misc/rarewhite,
 /area/f13/klamat)
 "akQ" = (
@@ -11663,12 +11644,6 @@
 /obj/effect/turf_decal/weather/snow/corner,
 /turf/open/floor/plating/ground/mountain,
 /area/f13/underground/mountain)
-"aLu" = (
-/obj/item/sign_backing{
-	icon_state = "bluecross2"
-	},
-/turf/closed/wall/rust,
-/area/f13/klamat)
 "aLv" = (
 /obj/machinery/door/unpowered/wooddoor,
 /turf/open/floor/wood/f13/old,
@@ -14900,12 +14875,6 @@
 /obj/item/trash/raisins,
 /turf/open/floor/plasteel/white,
 /area/f13/prison)
-"aWn" = (
-/obj/item/sign_backing{
-	icon_state = "chemistry2"
-	},
-/turf/closed/wall/rust,
-/area/f13/klamat)
 "aWo" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -15337,9 +15306,6 @@
 /obj/machinery/vending/tool,
 /turf/open/floor/plasteel/f13,
 /area/f13/underground/bos)
-"aXO" = (
-/turf/open/space/basic,
-/area/f13/sunny_dale)
 "aXP" = (
 /obj/structure/table,
 /obj/structure/showcase/machinery/tv,
@@ -89050,7 +89016,7 @@ aQS
 aQS
 aJX
 aQS
-aXO
+aQS
 aNT
 aVT
 aiz
@@ -89307,7 +89273,7 @@ aQS
 aQS
 aKY
 aQS
-aXO
+aQS
 aQS
 aVT
 aiz
@@ -89564,7 +89530,7 @@ aSt
 aRm
 aHR
 aQS
-aXO
+aQS
 aMD
 aVT
 aiz
@@ -142312,7 +142278,7 @@ aTI
 aTI
 aKh
 aiz
-aad
+afD
 aiz
 aiz
 aiz
@@ -175207,10 +175173,10 @@ aah
 aah
 aah
 aah
-aLu
+aah
 aOk
 aOk
-aLu
+aah
 aah
 aah
 aah
@@ -177263,7 +177229,7 @@ aNR
 aah
 aif
 aif
-ajo
+aah
 aif
 aif
 aZL
@@ -178804,12 +178770,12 @@ aah
 aWM
 aif
 aWi
-aWn
+aah
 aif
 aif
 aSI
 aEH
-aLu
+aah
 aif
 aLT
 aMH


### PR DESCRIPTION
<!-- HEY LISTEN!!! -->

<!-- WHEN MAKING A NEW PR TO THIS GIT, BE ABSOLUTELY SURE THE BASE REPO YOU'RE COMMITING TO ISN'T tgstation/tgstation IT SHOULD BE RobustTeam/tg-ashcloud -->

<!-- In edition changelogs won't be ultilized due to the way pulling from upstream tg will heavily filter out the old ones; instead change the changelog on the discord if we ever make one -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Removed three space tiles from the map.  obj/item/sign_backing is no longer a part of tgstation.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Space tiles are bad.  We'll have to see if tgstaiton replaced sign_backing with a new system.
